### PR TITLE
Update README to mention how to check if floating window is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ it's quite easy with Homebrew.
 $ brew install neovim --HEAD
 ```
 
+To check if Neovim's floating window feature is available, try ```:echo exists('*nvim_open_win')``` which should echo `1`.
 
 
 ## Usage


### PR DESCRIPTION
Guide users on how to check the floating window feature is
available in the bleeding-edge neovim: `exists('*nvim_open_win')`.