### PR TITLE
nvim_win_config was renamed

### DIFF
--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -190,7 +190,7 @@ function! s:popup__update() dict abort
                 return
             endif
             let opts = self.floating_win_opts(width, height)
-            call nvim_win_config(id, width, height, opts)
+            call nvim_win_set_config(id, width, height, opts)
 
             " Window is not repainted due to bug of Neovim
             "   https://github.com/neovim/neovim/issues/9699


### PR DESCRIPTION
nvim_win_config was renamed to nvim_win_set_config.
https://github.com/neovim/neovim/commit/3c88bbecb8dc2bf1fb426cce08af232640bfd44d

I fixed it