### PR TITLE
feat: add commit date to popup window

### DIFF
--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -142,18 +142,20 @@ function! s:blame__after_blame(git) dict abort
 
     let author = matchstr(stdout[1], '^author \zs.\+')
     let author_email = matchstr(stdout[2], '^author-mail \zs\S\+')
-    let author_time = matchstr(stdout[3], '^author-time \zs\d\+')
     let self.contents = [
         \   '',
         \   ' History: #' . len(self.history),
         \   ' Commit: ' . hash,
-        \   ' Date: ' . strftime('%c', author_time),
         \   ' Author: ' . author . ' ' . author_email,
         \ ]
     let committer = matchstr(stdout[5], '^committer \zs.\+')
     if author !=# committer
         let committer_email = matchstr(stdout[6], '^committer-mail \zs\S\+')
         let self.contents += [' Committer: ' . committer . ' ' . committer_email]
+    endif
+    if exists('*strftime')
+        let author_time = matchstr(stdout[3], '^author-time \zs\d\+')
+        let self.contents += [' Date: ' . strftime('%c', str2nr(author_time))]
     endif
     let summary = matchstr(stdout[9], '^summary \zs.*')
     let prev_hash = matchstr(stdout[10], '^previous \zs[[:xdigit:]]\+')

--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -142,10 +142,12 @@ function! s:blame__after_blame(git) dict abort
 
     let author = matchstr(stdout[1], '^author \zs.\+')
     let author_email = matchstr(stdout[2], '^author-mail \zs\S\+')
+    let author_time = matchstr(stdout[3], '^author-time \zs\d\+')
     let self.contents = [
         \   '',
         \   ' History: #' . len(self.history),
         \   ' Commit: ' . hash,
+        \   ' Date: ' . strftime('%c', author_time),
         \   ' Author: ' . author . ' ' . author_email,
         \ ]
     let committer = matchstr(stdout[5], '^committer \zs.\+')

--- a/syntax/gitmessengerpopup.vim
+++ b/syntax/gitmessengerpopup.vim
@@ -2,7 +2,7 @@ if exists('b:current_syntax')
     finish
 endif
 
-syn match gitmessengerHeader '\_^ \%(History\|Commit\|Author\|Committer\):' display
+syn match gitmessengerHeader '\_^ \%(History\|Commit\|Date\|Author\|Committer\):' display
 syn match gitmessengerHash '\%(\<Commit: \)\@<=[[:xdigit:]]\+' display
 syn match gitmessengerHistory '\%(\<History: \)\@<=#\d\+' display
 


### PR DESCRIPTION
Git message popup window missing commit date.
I added author-date from blame output.

As you can see:
![WX20190401-105116](https://user-images.githubusercontent.com/9718515/55300995-f9766d80-546c-11e9-9fb2-4b6644a989f0.png)
