### PR TITLE
keep the cursor's position after opening preview window

### DIFF
--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -124,11 +124,13 @@ function! s:popup__open() dict abort
         let opts = self.floating_win_opts(width, height)
         let win_id = nvim_open_win(self.opener_bufnr, v:true, opts)
     else
+        let curr_pos = getpos('.')
         let mods = 'noswapfile'
         if g:git_messenger_preview_mods !=# ''
             let mods .= ' ' . g:git_messenger_preview_mods
         endif
         execute mods 'pedit!'
+        call setpos('.', curr_pos)
         wincmd P
         execute height . 'wincmd _'
         let win_id = win_getid()


### PR DESCRIPTION
After opening preview window, the cursor will be moved to the top line of the main window.

I used `getpos` then `setpos` to keep the cursor's position from moving.