### PR TITLE
Use "minimal" style for floating window

### DIFF
--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -112,6 +112,7 @@ function! s:popup__floating_win_opts(width, height) dict abort
     \   'col': col,
     \   'width': a:width,
     \   'height': a:height,
+    \   'style': 'minimal',
     \ }
 endfunction
 let s:popup.floating_win_opts = funcref('s:popup__floating_win_opts')


### PR DESCRIPTION
Setting the `minimal` style for floating windows will disable a few options that are usually not needed in temporary floating windows where the text is not intended to be edited.

Fixes #40