### PR TITLE
Add highlight group for email

### DIFF
--- a/doc/git-messenger.txt
+++ b/doc/git-messenger.txt
@@ -273,6 +273,9 @@ For example:
 
   " History number at 'History:' header with 'Title' highlight group
   hi link gitmessengerHistory Title
+
+  " Email address at 'Author:' header with 'Comment' highlight group
+  hi link gitmessengerEmail Comment
 <
 For another example, if you want to define colors directly, defining the
 colors with |:hi| works fine as follows.
@@ -281,6 +284,7 @@ colors with |:hi| works fine as follows.
   hi gitmessengerHeader term=None guifg=#88b8f6 ctermfg=111
   hi gitmessengerHash term=None guifg=#f0eaaa ctermfg=229
   hi gitmessengerHistory term=None guifg=#fd8489 ctermfg=210
+  hi gitmessengerEmail term=None guifg=#999999 ctermfg=245
 <
 Note: If your colorscheme does not allocate proper color for |hl-NormalFloat|,
 you may need to set proper color to "gitmessengerPopupNormal".

--- a/syntax/gitmessengerpopup.vim
+++ b/syntax/gitmessengerpopup.vim
@@ -5,6 +5,7 @@ endif
 syn match gitmessengerHeader '\_^ \%(History\|Commit\|Date\|Author\|Committer\):' display
 syn match gitmessengerHash '\%(\<Commit: \)\@<=[[:xdigit:]]\+' display
 syn match gitmessengerHistory '\%(\<History: \)\@<=#\d\+' display
+syn match gitmessengerEmail '\%(\<\%(Author\|Committer\): .*\)\@<=<.\+>' display
 
 " Diff included in popup
 syn match diffRemoved "^ -.*" display
@@ -29,6 +30,7 @@ syn match diffIndexLine "^ index \x\{7,}\.\.\x\{7,}.*" display
 hi def link gitmessengerHeader      Identifier
 hi def link gitmessengerHash        Comment
 hi def link gitmessengerHistory     Constant
+hi def link gitmessengerEmail       gitmessengerPopupNormal
 hi def link gitmessengerPopupNormal NormalFloat
 
 hi def link diffOldFile   diffFile


### PR DESCRIPTION
Personally I like to highlight emails addresses in a different color to make them less visible. This adds a new highlight group for email addresses, which is by default linked to `gitmessengerPopupNormal` (to keep the default behavior unchanged).