### PR TITLE
Fix #55

### DIFF
--- a/autoload/gitmessenger/git.vim
+++ b/autoload/gitmessenger/git.vim
@@ -40,6 +40,10 @@ endfunction
 "     empty string means root directory was not found
 function! gitmessenger#git#root_dir(from) abort
     let from = fnamemodify(a:from, ':p')
+    if from[-1:] ==# s:SEP
+        " [:-2] chops last path separator
+        let from = from[:-2]
+    endif
     let dotgit = s:find_dotgit(from)
     if dotgit ==# ''
         return ''


### PR DESCRIPTION
This seems to be due to the presence of `\` at the end.
I have confirmed that it works only on Windows.
