### PR TITLE
Limitedly resolve Outside repository error

### DIFF
--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -426,7 +426,7 @@ function! gitmessenger#blame#new(file, line, opts) abort
     let b = deepcopy(s:blame)
     let b.state = gitmessenger#history#new(a:file)
     let b.line = a:line
-    let b.blame_file = a:file
+    let b.blame_file = fnamemodify(a:file, ':p:.')
     let b.opts = a:opts
 
     let dir = fnamemodify(a:file, ':p:h')


### PR DESCRIPTION
Limitedly resolve Outside repository error on Windows with msys/git.
#57 

The error can be suppressed only if the file can be specified by a relative path.