### PR TITLE
Resolved an issue where gitmessenger#git#root_dir() fails to resolve paths with spaces

### DIFF
--- a/autoload/gitmessenger/git.vim
+++ b/autoload/gitmessenger/git.vim
@@ -39,7 +39,7 @@ endfunction
 "   string
 "     empty string means root directory was not found
 function! gitmessenger#git#root_dir(from) abort
-    let from = fnamemodify(a:from, ':p')
+    let from = fnameescape(fnamemodify(a:from, ':p'))
     if from[-1:] ==# s:SEP
         " [:-2] chops last path separator
         let from = from[:-2]

--- a/test/all.vimspec
+++ b/test/all.vimspec
@@ -1058,6 +1058,40 @@ Describe git-messenger.vim
             Assert True(index(lines, '  bbb') > 0, msg)
         End
     End
+   
+    Describe gitmessenger#git#root_dir()
+        Before all
+            let root_dir = './my git root with space'
+            let file = 'file.txt'
+            let path = root_dir . '/' . file
+
+            call mkdir(root_dir)
+            call writefile(['123'], path)
+            
+            call Git(fnameescape(root_dir), 'init', '.')
+            call Git(fnameescape(root_dir), 'add', file)
+            call Git(fnameescape(root_dir), 'commit', '-m', 'init')
+        End
+
+        After all
+            if delete(root_dir, 'rf') != 0
+                throw 'delete() failed'
+            endif
+        End
+
+        It returns correct root when pathname contains space
+
+            " call fnamemodify here the same way
+            " gitmessenger#blame#new() does to get our absolute path
+            let file = './my git root with space/file.txt'
+            let expected_root_dir = fnamemodify(file, ':p:h')
+            let actual_root_dir = gitmessenger#git#root_dir(file)
+            
+            " Failure will return the repo root instead of our created
+            " ad-hoc root directory
+            Assert Equal(actual_root_dir, expected_root_dir)
+        End
+    End
 End
 
 " vim: set ft=vim:


### PR DESCRIPTION
[Addresses the issue](https://github.com/rhysd/git-messenger.vim/issues/60) where a file path that includes a space fails to resolve in `gitmessenger#git#root_dir()` 

In `gitmessenger#git#root_dir()`, I tweaked things to escape the file path which should allow git to properly find the directory.

Tested on MacOS, and Linux. Haven't tested in Windows