### PR TITLE
Word-diff feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Following mappings are defined within popup window.
 |   `O`   | Opposite to `o`. Forward to newer commit at the line         |
 |   `d`   | Toggle diff hunks only related to current file in the commit |
 |   `D`   | Toggle all diff hunks in the commit                          |
+|   `r`   | Toggle current file's word diffs of current commit           |
+|   `R`   | Toggle all word diffs of current commit                      |
 |   `?`   | Show mappings help                                           |
 
 ### Mappings
@@ -178,8 +180,8 @@ When this value is not set to `"none"`, a popup window includes diff hunks of th
 up. `"current"` includes diff hunks of only current file in the commit. `"all"` includes all diff
 hunks in the commit.
 
-Please note that typing `d` and `D` in popup window toggle showing diff hunks even if this value is
-set to `"none"`.
+Please note that typing `d`/`D` or `r`/`R` in popup window toggle showing diff
+hunks even if this value is set to `"none"`.
 
 #### `g:git_messenger_git_command` (Default: `"git"`)
 

--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -72,8 +72,10 @@ function! s:blame__open_popup() dict abort
         \       'q': [{-> execute('close', '')}, 'Close popup window'],
         \       'o': [funcref(self.back, [], self), 'Back to older commit'],
         \       'O': [funcref(self.forward, [], self), 'Forward to newer commit'],
-        \       'd': [funcref(self.reveal_diff, [v:false], self), "Toggle current file's diffs of current commit"],
-        \       'D': [funcref(self.reveal_diff, [v:true], self), 'Toggle all diffs of current commit'],
+        \       'd': [funcref(self.reveal_diff, [v:false, v:false], self), "Toggle current file's diffs of current commit"],
+        \       'D': [funcref(self.reveal_diff, [v:true, v:false], self), 'Toggle all diffs of current commit'],
+        \       'r': [funcref(self.reveal_diff, [v:false, v:true], self), "Toggle current file's word diffs of current commit"],
+        \       'R': [funcref(self.reveal_diff, [v:true, v:true], self), 'Toggle all word diffs of current commit'],
         \   },
         \ }
     if has_key(self.opts, 'did_close')
@@ -158,7 +160,7 @@ function! s:blame__after_diff(next_diff, git) dict abort
     endif
 endfunction
 
-function! s:blame__reveal_diff(include_all) dict abort
+function! s:blame__reveal_diff(include_all, word_diff) dict abort
     if a:include_all
         let next_diff = 'all'
     else
@@ -197,6 +199,10 @@ function! s:blame__reveal_diff(include_all) dict abort
     else
         " When the line is not committed yet, show diff against HEAD (#26)
         let args = ['--no-pager', 'diff', '--no-color', 'HEAD']
+    endif
+
+    if a:word_diff
+        let args += ['--word-diff=plain']
     endif
 
     if !a:include_all

--- a/doc/git-messenger.txt
+++ b/doc/git-messenger.txt
@@ -135,6 +135,8 @@ COMMANDS                                                *git-messenger-commands*
   |    O    | Opposite to older. Forward to newer commit at the line       |
   |    d    | Toggle diff hunks only related to current file in the commit |
   |    D    | Toggle all diff hunks in the commit                          |
+  |    r    | Toggle current file's word diffs of current commit           |
+  |    R    | Toggle all word diffs of current commit                      |
   |    ?    | Show mappings help                                           |
 
 *:GitMessengerClose*
@@ -203,8 +205,8 @@ Some global variables are available to configure the behavior of this plugin.
 
   When this value is set to |v:true|, a popup window includes diff hunks of the
   commit by default.
-  Note: Typing "d" in popup window reveals diff hunks even if this value is
-  set to |v:false|.
+  Note: Typing "d" or "r" in popup window reveals diff hunks even if this
+  value is set to |v:false|.
 
   One of "none", "current", "all".
 
@@ -212,8 +214,8 @@ Some global variables are available to configure the behavior of this plugin.
   the commit at showing up. "current" includes diff hunks of only current file
   in the commit. "all" includes all diff hunks in the commit.
 
-  Note: Typing d and D mappings in popup window reveal diff hunks even if this
-  value is set to "none".
+  Note: Typing d/D or r/R mappings in popup window reveal diff hunks even if
+  this value is set to "none".
 
 *g:git_messenger_git_command* (Default: "git")
 

--- a/syntax/gitmessengerpopup.vim
+++ b/syntax/gitmessengerpopup.vim
@@ -10,6 +10,8 @@ syn match gitmessengerEmail '\%(\_^ \<\%(Author\|Committer\): \+.*\)\@<=<.\+>' d
 " Diff included in popup
 syn match diffRemoved "^ -.*" display
 syn match diffAdded "^ +.*" display
+syn match diffWordsRemoved "\[\-.\{-}\-\]" display
+syn match diffWordsAdded "{+.\{-}+}" display
 
 syn match diffSubname "  @@..*"ms=s+3 contained display
 syn match diffLine "^ @.*" contains=diffSubname display
@@ -33,13 +35,15 @@ hi def link gitmessengerHistory     Constant
 hi def link gitmessengerEmail       gitmessengerPopupNormal
 hi def link gitmessengerPopupNormal NormalFloat
 
-hi def link diffOldFile   diffFile
-hi def link diffNewFile   diffFile
-hi def link diffIndexLine PreProc
-hi def link diffFile      Type
-hi def link diffRemoved   Special
-hi def link diffAdded     Identifier
-hi def link diffLine      Statement
-hi def link diffSubname   PreProc
+hi def link diffOldFile      diffFile
+hi def link diffNewFile      diffFile
+hi def link diffIndexLine    PreProc
+hi def link diffFile         Type
+hi def link diffRemoved      Special
+hi def link diffAdded        Identifier
+hi def link diffWordsRemoved diffRemoved
+hi def link diffWordsAdded   diffAdded
+hi def link diffLine         Statement
+hi def link diffSubname      PreProc
 
 let b:current_syntax = 'gitmessengerpopup'

--- a/syntax/gitmessengerpopup.vim
+++ b/syntax/gitmessengerpopup.vim
@@ -10,8 +10,8 @@ syn match gitmessengerEmail '\%(\_^ \<\%(Author\|Committer\): \+.*\)\@<=<.\+>' d
 " Diff included in popup
 syn match diffRemoved "^ -.*" display
 syn match diffAdded "^ +.*" display
-syn match diffWordsRemoved "\[\-.\{-}\-\]" display
-syn match diffWordsAdded "{+.\{-}+}" display
+syn region diffWordsRemoved start=/\[\-/ end=/\-\]/
+syn region diffWordsAdded start=/{+/ end=/+}/
 
 syn match diffSubname "  @@..*"ms=s+3 contained display
 syn match diffLine "^ @.*" contains=diffSubname display


### PR DESCRIPTION
First draft of the word-diff feature, implementing #66. Word-diff mode is toggled via `r` and `R` (as in wo[r]d-diff)

Tests pass locally with `vim-themis` using both vim v8.2 and v0.4.4, although there are 2 pending tests (41 and 42) with `vim` with the message: "_# width of preview window cannot be changed_" which makes sense since they are skipped if we don't have neovim 0.4.

Docs and syntax files have been updated as well. Hopefully this is close to the desired implementation but please provide some feedback if not 🙂

![image](https://user-images.githubusercontent.com/1846147/106392552-a5cf6500-63f2-11eb-8409-7ed0c3c9a865.png)

**EDIT:** There is something fishy going on with the [action-setup-vim](https://github.com/rhysd/git-messenger.vim/runs/1801957774?check_suite_focus=true) and the command `sudo apt install -y vim-gnome`. Not sure what the problem is but I'll try to investigate. Perhaps it has something to do with the fact that GitHub Actions recently upgraded `ubuntu-latest` to 20.04.1 LTS from 18.04.5 LTS.