### PR TITLE
Add option to override float window options with variable

### DIFF
--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -111,7 +111,7 @@ function! s:popup__floating_win_opts(width, height) dict abort
         let col = self.opened_at[1]
     endif
 
-    return {
+    return extend({
     \   'relative': 'editor',
     \   'anchor': vert . hor,
     \   'row': row,
@@ -119,7 +119,9 @@ function! s:popup__floating_win_opts(width, height) dict abort
     \   'width': a:width,
     \   'height': a:height,
     \   'style': 'minimal',
-    \ }
+    \ },
+    \ get(g:, 'git_messenger_floating_win_opts', {}),
+    \ 'force')
 endfunction
 let s:popup.floating_win_opts = funcref('s:popup__floating_win_opts')
 


### PR DESCRIPTION
The main use case of this is to set this is Neovim:

```vim
let g:git_messenger_floating_win_opts = {
   \ 'border': 'single'
   \ }
```

Closes #73.