### PR TITLE
add /doc/tags to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /htmlcov
 /coverage.xml
 /.coverage_covimerage
+/doc/tags


### PR DESCRIPTION
allows generating tags file for `:help` vim command without having to dirty the repo