### PR TITLE
fix ignore BufEnter and BufLeave events when create popup window

### DIFF
--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -211,7 +211,7 @@ function! s:popup__open() dict abort
     execute 'autocmd BufWipeout,BufLeave <buffer> call getbufvar(' . popup_bufnr . ', "__gitmessenger_popup").close()'
 
     if has_key(self.opts, 'enter') && !self.opts.enter
-        noautocmd wincmd p
+        wincmd p
         if self.type !=# 'floating'
             " Opening a preview window may move global position of the cursor.
             " `opened_at` is used for checking if the popup window should be


### PR DESCRIPTION
After popup window has been created, git-messenager uses
`noautocmd wincmd p` to jump back to the current buffer, which
ignores BufEnter and BufLeave events. Some other plugins depends
on event BufEnter/BufLeave to take effect normally. So git-messenager
should use `wincmd p` to preserve events.

See issue #65 for details.