### PR TITLE
Fix diff toggle when margins are off

### DIFF
--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -196,9 +196,10 @@ function! s:blame__reveal_diff(include_all, word_diff) dict abort
     try
         keepjumps execute 1
         let diff_pattern = g:git_messenger_popup_content_margins ? '^ diff --git ' : '^diff --git '
+        let diff_offset = g:git_messenger_popup_content_margins ? 2 : 3
         let diff_start = search(diff_pattern, 'ncW')
         if diff_start > 1
-            let self.state.contents = self.state.contents[ : diff_start-2]
+            let self.state.contents = self.state.contents[ : diff_start-diff_offset]
         endif
     finally
         keepjumps call setpos('.', saved)

--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -195,7 +195,8 @@ function! s:blame__reveal_diff(include_all, word_diff) dict abort
     let saved = getpos('.')
     try
         keepjumps execute 1
-        let diff_start = search('^ diff --git ', 'ncW')
+        let diff_pattern = g:git_messenger_popup_content_margins ? '^ diff --git ' : '^diff --git '
+        let diff_start = search(diff_pattern, 'ncW')
         if diff_start > 1
             let self.state.contents = self.state.contents[ : diff_start-2]
         endif

--- a/test/all.vimspec
+++ b/test/all.vimspec
@@ -410,10 +410,14 @@ Describe git-messenger.vim
                 let ReadmeDiffNoMarginsExists = {-> index(getline(1, '$'), 'diff --git a/README.md b/README.md') !=# -1}
 
                 GitMessenger
-                Assert IsNotNone(GetPopup())
+
+                let p = GetPopup()
+                Assert IsNotNone(p)
+
                 GitMessenger
                 Assert Exists('b:__gitmessenger_popup')
 
+                let num_lines = len(getbufline(p.bufnr, 1, '$'))
                 let expected = v:true
                 for i in range(3)
                     normal d
@@ -421,6 +425,10 @@ Describe git-messenger.vim
                     let lines = 'Got lines (' . i . '): ' . string(getline(1, '$'))
                     Assert Equal(found, expected, lines)
                     Assert False(ReadmeDiffNoMarginsExists(), lines)
+                    " Repeated toggling should not grow the buffer size
+                    if !expected
+                        Assert Equal(len(getline(1, '$')), num_lines, lines)
+                    endif
                     " Flip expectation because d toggles file diff
                     let expected = !expected
                 endfor
@@ -452,10 +460,14 @@ Describe git-messenger.vim
                 let ReadmeDiffNoMarginsExists = {-> index(getline(1, '$'), 'diff --git a/README.md b/README.md') !=# -1}
 
                 GitMessenger
-                Assert IsNotNone(GetPopup())
+
+                let p = GetPopup()
+                Assert IsNotNone(p)
+
                 GitMessenger
                 Assert Exists('b:__gitmessenger_popup')
 
+                let num_lines = len(getbufline(p.bufnr, 1, '$'))
                 let expected = v:true
                 for i in range(3)
                     normal D
@@ -463,6 +475,10 @@ Describe git-messenger.vim
                     let lines = 'Got lines (' . i . '): ' . string(getline(1, '$'))
                     Assert Equal(found, expected, lines)
                     Assert Equal(LicenseDiffNoMarginsExists(), expected, lines)
+                    " Repeated toggling should not grow the buffer size
+                    if !expected
+                        Assert Equal(len(getline(1, '$')), num_lines, lines)
+                    endif
                     " Flip expectation because D toggles commit diff
                     let expected = !expected
                 endfor

--- a/test/all.vimspec
+++ b/test/all.vimspec
@@ -404,6 +404,30 @@ Describe git-messenger.vim
                 endfor
             End
 
+            It toggles file diff on d -> d when margins are off
+                let g:git_messenger_popup_content_margins = v:false
+                let LicenseDiffNoMarginsExists = {-> index(getline(1, '$'), 'diff --git a/LICENSE b/LICENSE') !=# -1}
+                let ReadmeDiffNoMarginsExists = {-> index(getline(1, '$'), 'diff --git a/README.md b/README.md') !=# -1}
+
+                GitMessenger
+                Assert IsNotNone(GetPopup())
+                GitMessenger
+                Assert Exists('b:__gitmessenger_popup')
+
+                let expected = v:true
+                for i in range(3)
+                    normal d
+                    let found = WaitUntil(LicenseDiffNoMarginsExists)
+                    let lines = 'Got lines (' . i . '): ' . string(getline(1, '$'))
+                    Assert Equal(found, expected, lines)
+                    Assert False(ReadmeDiffNoMarginsExists(), lines)
+                    " Flip expectation because d toggles file diff
+                    let expected = !expected
+                endfor
+
+                let g:git_messenger_popup_content_margins = v:true
+            End
+
             It toggles commit diff on D -> D
                 GitMessenger
                 Assert IsNotNone(GetPopup())
@@ -420,6 +444,30 @@ Describe git-messenger.vim
                     " Flip expectation because D toggles commit diff
                     let expected = !expected
                 endfor
+            End
+
+            It toggles commit diff on D -> D when margins are off
+                let g:git_messenger_popup_content_margins = v:false
+                let LicenseDiffNoMarginsExists = {-> index(getline(1, '$'), 'diff --git a/LICENSE b/LICENSE') !=# -1}
+                let ReadmeDiffNoMarginsExists = {-> index(getline(1, '$'), 'diff --git a/README.md b/README.md') !=# -1}
+
+                GitMessenger
+                Assert IsNotNone(GetPopup())
+                GitMessenger
+                Assert Exists('b:__gitmessenger_popup')
+
+                let expected = v:true
+                for i in range(3)
+                    normal D
+                    let found = WaitUntil(ReadmeDiffNoMarginsExists)
+                    let lines = 'Got lines (' . i . '): ' . string(getline(1, '$'))
+                    Assert Equal(found, expected, lines)
+                    Assert Equal(LicenseDiffNoMarginsExists(), expected, lines)
+                    " Flip expectation because D toggles commit diff
+                    let expected = !expected
+                endfor
+
+                let g:git_messenger_popup_content_margins = v:true
             End
 
             It switches diff between 'all' and 'current' repeatedly


### PR DESCRIPTION
## Overview
Diff toggling does not work when `g:git_messenger_popup_content_margins = v:false`. Instead of toggling, diffs are appended to the buffer on every other call.

## Proposed Fix
Update `blame__reveal_diff()` in blame.vim to account for margins. It will pick between `^ diff --git ` and `^diff --git ` search patterns when looking for `diff_start`, depending on the current state of `g:git_messenger_popup_content_margins`.

## Tests

```
$ THEMIS_VIM=vi ./vim-themis/bin/themis test/all.vimspec

...

ok 25 - git-messenger.vim Popup window diff support toggles file diff on d -> d
ok 26 - git-messenger.vim Popup window diff support toggles file diff on d -> d when margins are off
ok 27 - git-messenger.vim Popup window diff support toggles commit diff on D -> D
ok 28 - git-messenger.vim Popup window diff support toggles commit diff on D -> D when margins are off

...

# tests 61
# passes 58
# pendings 3
```