### PR TITLE
fix: update unified diff highlight after toggling word diff

### DIFF
--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -25,7 +25,7 @@ function! s:blame__render() dict abort
         call self.popup.set_buf_var('__gitmessenger_diff', self.state.diff)
         let prev_is_word = self.state.prev_diff =~# '\.word$'
         let is_word = self.state.diff =~# '\.word$'
-        if self.state.diff !=# 'none' && prev_is_word != is_word
+        if self.state.diff !=# 'none' && (self.state.prev_diff == 'none' || prev_is_word != is_word)
             call self.popup.set_buf_var('&syntax', 'gitmessengerpopup')
         endif
     endif


### PR DESCRIPTION
Closes https://github.com/rhysd/git-messenger.vim/issues/92

Problem:

When pressing `r` twice to toggle word diff followed by pressing `d` to open unified diff, `state.prev_diff` will be `none` and `state.diff` will be `current`. Both `prev_is_word` and `is_word` will be `0`, so that `if` block to update syntax will be skipped.

Solution:

Update syntax if `prev_diff` is `none`.

Thank you!