### PR TITLE
feat: support bare repo

### DIFF
--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -442,7 +442,7 @@ function! s:blame__after_blame(git) dict abort
 endfunction
 
 function! s:blame__spawn_git(args, callback) dict abort
-    let git = gitmessenger#git#new(g:git_messenger_git_command, self.git_root)
+    let git = gitmessenger#git#new(g:git_messenger_git_command, self.gitdir, self.worktree)
     let CB = a:callback
     if type(CB) == v:t_string
         let CB = funcref(CB, [], self)
@@ -465,7 +465,8 @@ let s:blame.start = funcref('s:blame__start')
 " interface Blame {
 "   state: BlameHistory;
 "   line: number;
-"   git_root: string;
+"   gitdir: string;
+"   worktree: string;
 "   blame_file: string;
 "   prev_commit?: string;
 "   oldest_commit?: string;
@@ -490,10 +491,12 @@ function! gitmessenger#blame#new(file, line, opts) abort
     let b.opts = a:opts
 
     let dir = fnamemodify(file, ':p:h')
-    let b.git_root = gitmessenger#git#root_dir(dir)
+    let gitdir = gitmessenger#git#gitdir(dir)
+    let b.gitdir = gitdir !=# '' ? gitdir : $GIT_DIR
+    let b.worktree = $GIT_WORK_TREE !=# '' ? fnamemodify($GIT_WORK_TREE, ':p') : fnamemodify(gitdir, ':h')
 
     " Validations
-    if b.git_root ==# ''
+    if b.gitdir ==# ''
         call b.error("git-messenger: Directory '" . dir . "' is not inside a Git repository")
         return v:null
     endif

--- a/test/all.vimspec
+++ b/test/all.vimspec
@@ -1290,7 +1290,7 @@ Describe git-messenger.vim
         End
     End
 
-    Describe gitmessenger#git#root_dir()
+    Describe gitmessenger#git#gitdir()
         Before all
             let root_dir = './my git root with space'
             let file = 'file.txt'
@@ -1314,12 +1314,12 @@ Describe git-messenger.vim
             " call fnamemodify here the same way
             " gitmessenger#blame#new() does to get our absolute path
             let file = './my git root with space/file.txt'
-            let expected_root_dir = fnamemodify(file, ':p:h')
-            let actual_root_dir = gitmessenger#git#root_dir(file)
+            let expected_gitdir = fnamemodify(file, ':p:h') .. '/.git'
+            let actual_gitdir = gitmessenger#git#gitdir(file)
 
             " Failure will return the repo root instead of our created
             " ad-hoc root directory
-            Assert Equal(actual_root_dir, expected_root_dir)
+            Assert Equal(actual_gitdir, expected_gitdir)
         End
     End
 
@@ -1441,8 +1441,8 @@ Describe git-messenger.vim
     End
 
     Describe gitmessenger#git#new
-        It runs Git command at specified directory using -C
-            let git = gitmessenger#git#new('echo', '.')
+        It runs Git command at specified directory using --git-dir and --work-tree
+            let git = gitmessenger#git#new('echo', '.', '.')
             let state = {}
             let OnExit = {g -> extend(state, {'exit': g.exit_status})}
 
@@ -1451,11 +1451,11 @@ Describe git-messenger.vim
 
             Assert True(len(git.stdout) > 0, string(git.stdout))
             let stdout = git.stdout[0]
-            Assert True(stridx(stdout, '-C .') >= 0, string(stdout))
+            Assert True(stridx(stdout, '--git-dir . --work-tree .') >= 0, string(stdout))
         End
 
         It trims trailing \r (#75)
-            let git = gitmessenger#git#new('echo', '.')
+            let git = gitmessenger#git#new('echo', '.', '.')
             let state = {}
             let OnExit = {g -> extend(state, {'exit': g.exit_status})}
 


### PR DESCRIPTION
Closes https://github.com/rhysd/git-messenger.vim/issues/84

**Solution:**

Change `git -C` to `git --git-dir /path/to/gitdir --work-tree /path/to/worktree`. `gitdir` is the directory containing `.git` or the value of `$GIT_DIR` env. `worktree` is the value of `$GIT_WORK_TREE` env or the parent directory of `gitdir`.

I've been using git bare repo to manage my dot files for years and it works very well in my bare repo.

**Test:**

<img width="1728" alt="Screenshot 2025-05-17 at 20 33 38" src="https://github.com/user-attachments/assets/9042c3c7-b465-4690-a8f9-438ecb7e95e9" />

...

<img width="1728" alt="Screenshot 2025-05-17 at 20 33 46" src="https://github.com/user-attachments/assets/d46238b2-5d26-4952-90c0-09ee8fff7fa3" />

Thank you.