### PR TITLE
Add support for Vim 8.1+ popup windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ Setting `v:false` to this variable removes all the margins.
 
 When this value is set to `v:true`, enables the use of popup windows in Vim. This feature is
 experimental, and has some limitations as it is not possible to enter a popup window in Vim (unlike
-floating windows in Neovim). Similar to using Neovim with `g:git_messenger_always_into_popup` set to `v:true`.
+floating windows in Neovim). Entering a popup is emulated by initially disabling keyboard mappings
+for the popup window, and only enabling them when it been marked as "entered", either by running the
+`:GitMessenger` command a second time, or with `g:git_messenger_always_into_popup` set to `v:true`.
 
 #### `g:git_messenger_vimpopup_win_opts` (Default `{}`)
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Following mappings are defined within popup window.
 | `D`     | Toggle all unified diff hunks of the commit                  |
 | `r`     | Toggle word diff hunks only in current file of the commit    |
 | `R`     | Toggle all word diff hunks of current commit                 |
+| `c`     | Yank/copy the current commit hash to `v:register`            |
 | `?`     | Show mappings help                                           |
 
 ### Mappings

--- a/README.md
+++ b/README.md
@@ -261,6 +261,23 @@ Setting `v:true` means adding margins in popup window. Blank lines at the top an
 content are inserted. And every line is indented with one whitespace character.
 Setting `v:false` to this variable removes all the margins.
 
+#### `g:git_messenger_vimpopup_enabled` (Default: `v:false`)
+
+When this value is set to `v:true`, enables the use of popup windows in Vim. This feature is
+experimental, and has some limitations as it is not possible to enter a popup window in Vim (unlike
+floating windows in Neovim). Similar to using Neovim with `g:git_messenger_always_into_popup` set to `v:true`.
+
+#### `g:git_messenger_vimpopup_win_opts` (Default `{}`)
+
+Options passed to `popup_create()` on opening a popup window in Vim. This is useful when you want to
+override some window options. See `:help popup-usage`.
+
+The following example will add a border to the window in the default style.
+
+```vim
+let g:git_messenger_vimpopup_win_opts = { 'border': [] }
+```
+
 ### Popup Window Highlight
 
 This plugin uses color definitions from your colorscheme for highlighting stuffs in popup window by

--- a/autoload/gitmessenger.vim
+++ b/autoload/gitmessenger.vim
@@ -11,6 +11,8 @@ let g:git_messenger_max_popup_width = get(g:, 'git_messenger_max_popup_width', v
 let g:git_messenger_date_format = get(g:, 'git_messenger_date_format', '%c')
 let g:git_messenger_conceal_word_diff_marker = get(g:, 'git_messenger_conceal_word_diff_marker', 1)
 let g:git_messenger_floating_win_opts = get(g:, 'git_messenger_floating_win_opts', {})
+let g:git_messenger_vimpopup_enabled = get(g:, 'git_messenger_vimpopup_enabled', v:false)
+let g:git_messenger_vimpopup_win_opts = get(g:, 'git_messenger_vimpopup_win_opts', {})
 let g:git_messenger_popup_content_margins = get(g:, 'git_messenger_popup_content_margins', v:true)
 
 " All popup instances keyed by opener's bufnr to manage lifetime of popups

--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -192,18 +192,26 @@ function! s:blame__reveal_diff(include_all, word_diff) dict abort
     endif
 
     " Remove diff hunks from popup
-    let saved = getpos('.')
-    try
-        keepjumps execute 1
-        let diff_pattern = g:git_messenger_popup_content_margins ? '^ diff --git ' : '^diff --git '
-        let diff_offset = g:git_messenger_popup_content_margins ? 2 : 3
-        let diff_start = search(diff_pattern, 'ncW')
-        if diff_start > 1
+    let diff_pattern = g:git_messenger_popup_content_margins ? '^ diff --git ' : '^diff --git '
+    if has_key(self, 'popup') && has_key(self.popup, 'type') && self.popup.type ==# 'popup'
+        let diff_offset = g:git_messenger_popup_content_margins ? 1 : 2
+        let diff_start = match(self.state.contents, diff_pattern)
+        if diff_start > 0
             let self.state.contents = self.state.contents[ : diff_start-diff_offset]
         endif
-    finally
-        keepjumps call setpos('.', saved)
-    endtry
+    else
+        let diff_offset = g:git_messenger_popup_content_margins ? 2 : 3
+        let saved = getpos('.')
+        try
+            keepjumps execute 1
+            let diff_start = search(diff_pattern, 'ncW')
+            if diff_start > 1
+                let self.state.contents = self.state.contents[ : diff_start-diff_offset]
+            endif
+        finally
+            keepjumps call setpos('.', saved)
+        endtry
+    endif
 
     if next_diff ==# 'none'
         let self.state.diff = next_diff

--- a/autoload/gitmessenger/blame.vim
+++ b/autoload/gitmessenger/blame.vim
@@ -63,6 +63,22 @@ function! s:blame__forward() dict abort
 endfunction
 let s:blame.forward = funcref('s:blame__forward')
 
+function! s:blame__yank_hash() dict abort
+    " Note: v:register is blackhole here when vim-cutlass plugin used
+    " TODO: investigate further, it should be possible to use v:register
+    let register = '"'
+    if has('clipboard')
+        if stridx(&clipboard, 'unnamedplus') != -1
+            let register = '+'
+        elseif stridx(&clipboard, 'unnamed') != -1
+            let register = '*'
+        endif
+    endif
+    call setreg(register, self.state.commit)
+    echo 'git-messenger: yanked commit hash ' . self.state.commit
+endfunction
+let s:blame.yank_hash = funcref('s:blame__yank_hash')
+
 function! s:blame__open_popup() dict abort
     if has_key(self, 'popup') && has_key(self.popup, 'bufnr')
         " Already popup is open. It means that now older commit is showing up.
@@ -80,6 +96,7 @@ function! s:blame__open_popup() dict abort
         \       'q': [{-> execute('close', '')}, 'Close popup window'],
         \       'o': [funcref(self.back, [], self), 'Back to older commit'],
         \       'O': [funcref(self.forward, [], self), 'Forward to newer commit'],
+        \       'c': [funcref(self.yank_hash, [], self), 'Yank/copy current commit hash'],
         \       'd': [funcref(self.reveal_diff, [v:false, v:false], self), "Toggle current file's diffs"],
         \       'D': [funcref(self.reveal_diff, [v:true, v:false], self), 'Toggle all diffs'],
         \       'r': [funcref(self.reveal_diff, [v:false, v:true], self), "Toggle current file's word diffs"],

--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -241,11 +241,14 @@ function! s:popup__vimpopup_win_opts(width, height) dict abort
     " always enabled when needed, so handle scroll in filter function instead.
     " This now works the same as Neovim, no scrollbar, but mouse scroll works.
     return extend({
+        \   'filter': self.vimpopup_win_filter,
+        \   'callback': self.vimpopup_win_callback,
+        \ },
+        \ extend({
         \   'line': row,
         \   'col': col,
         \   'pos': vert . hor,
         \   'filtermode': 'n',
-        \   'filter': self.vimpopup_win_filter,
         \   'minwidth': a:width,
         \   'maxwidth': a:width,
         \   'minheight': a:height,
@@ -253,7 +256,7 @@ function! s:popup__vimpopup_win_opts(width, height) dict abort
         \   'scrollbar': v:false,
         \   'highlight': 'gitmessengerPopupNormal'
         \ },
-        \ g:git_messenger_vimpopup_win_opts)
+        \ g:git_messenger_vimpopup_win_opts), 'error')
 endfunction
 let s:popup.vimpopup_win_opts = funcref('s:popup__vimpopup_win_opts')
 
@@ -286,7 +289,6 @@ function! s:popup__open() dict abort
         " Allow multiple invocations of :GitMessenger command to toggle popup
         " See gitmessenger#popup#close_current_popup() and gitmessenger#new()
         let b:__gitmessenger_popup = self " local to opener, removed by callback
-        call popup_setoptions(win_id, { 'callback': self.vimpopup_win_callback })
         let self.bufnr = winbufnr(win_id)
         let self.win_id = win_id
         return

--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -299,6 +299,8 @@ function! s:popup__open() dict abort
         " Allow multiple invocations of :GitMessenger command to toggle popup
         " See gitmessenger#popup#close_current_popup() and gitmessenger#new()
         let b:__gitmessenger_popup = self " local to opener, removed by callback
+        " Also ensure popup closed and callback called when leaving opener
+        autocmd BufWipeout,BufLeave <buffer> ++once silent! call b:__gitmessenger_popup.close()
         let self.bufnr = winbufnr(win_id)
         let self.win_id = win_id
         return

--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -263,8 +263,8 @@ let s:popup.vimpopup_win_opts = funcref('s:popup__vimpopup_win_opts')
 function! s:popup__vimpopup_win_callback(win_id, result) dict abort
     " Hacky custom cleanup for vimpopup, necessary as buffer never entered
     silent! unlet b:__gitmessenger_popup
-    autocmd! plugin-git-messenger-close * <buffer>
-    autocmd! plugin-git-messenger-buf-enter
+    silent! autocmd! plugin-git-messenger-close * <buffer>
+    silent! autocmd! plugin-git-messenger-buf-enter
 endfunction
 let s:popup.vimpopup_win_callback = funcref('s:popup__vimpopup_win_callback')
 

--- a/autoload/gitmessenger/popup.vim
+++ b/autoload/gitmessenger/popup.vim
@@ -12,9 +12,7 @@ function! s:popup__close() dict abort
         return
     endif
 
-    if self.type ==# 'popup'
-        call popup_close(self.win_id)
-    else
+    if self.type !=# 'popup'
         let winnr = self.get_winnr()
         if winnr > 0
             " Without this 'noautocmd', the BufWipeout event will be triggered and
@@ -183,7 +181,7 @@ function! s:popup__vimpopup_win_filter(win_id, key) dict abort
     " cannot enter the popup window, so we override the handling here for now
     let keymaps = self.vimpopup_keymaps()
     if a:key ==# 'q'
-        call self.close()
+        call popup_close(a:win_id)
     elseif a:key ==# '?'
         call self.echo_help()
     elseif has_key(self.opts, 'mappings') && has_key(self.opts.mappings, a:key)
@@ -266,7 +264,7 @@ endfunction
 let s:popup.vimpopup_win_opts = funcref('s:popup__vimpopup_win_opts')
 
 function! s:popup__vimpopup_win_callback(win_id, result) dict abort
-    " Hacky custom cleanup for vimpopup, necessary as buffer never entered
+    silent! call b:__gitmessenger_popup.close()
     silent! unlet b:__gitmessenger_popup
     silent! autocmd! plugin-git-messenger-close * <buffer>
     silent! autocmd! plugin-git-messenger-buf-enter
@@ -300,7 +298,8 @@ function! s:popup__open() dict abort
         " See gitmessenger#popup#close_current_popup() and gitmessenger#new()
         let b:__gitmessenger_popup = self " local to opener, removed by callback
         " Also ensure popup closed and callback called when leaving opener
-        autocmd BufWipeout,BufLeave <buffer> ++once silent! call b:__gitmessenger_popup.close()
+        autocmd BufWipeout,BufLeave <buffer> ++once silent!
+          \ call popup_close(b:__gitmessenger_popup.win_id)
         let self.bufnr = winbufnr(win_id)
         let self.win_id = win_id
         return

--- a/doc/git-messenger.txt
+++ b/doc/git-messenger.txt
@@ -301,8 +301,11 @@ might be useful when you enable borders of popup window with
 
 When this value is set to |v:true|, enables the use of popup windows in Vim.
 This feature is experimental, and has some limitations as it is not possible
-to enter a popup window in Vim (unlike floating windows in Neovim). Similar
-to using Neovim with |g:git_messenger_always_into_popup| set to |v:true|.
+to enter a popup window in Vim (unlike floating windows in Neovim). Entering a
+popup is emulated by initially disabling keyboard mappings for the popup
+window, and only enabling them when it been marked as "entered", either by
+running the |:GitMessenger| command a second time, or with
+|g:git_messenger_always_into_popup| set to |v:true|.
 
 *g:git_messenger_vimpopup_win_opts* (Default |{}|)
 

--- a/doc/git-messenger.txt
+++ b/doc/git-messenger.txt
@@ -297,6 +297,23 @@ Setting |v:false| to this variable removes all the margins. Removing margins
 might be useful when you enable borders of popup window with
 |g:git_messenger_floating_win_opts|.
 
+*g:git_messenger_vimpopup_enabled* (Default: |v:false|)
+
+When this value is set to |v:true|, enables the use of popup windows in Vim.
+This feature is experimental, and has some limitations as it is not possible
+to enter a popup window in Vim (unlike floating windows in Neovim). Similar
+to using Neovim with |g:git_messenger_always_into_popup| set to |v:true|.
+
+*g:git_messenger_vimpopup_win_opts* (Default |{}|)
+
+Options passed to `popup_create()` on opening a popup window in Vim. This is
+useful when you want to override some window options. See |popup-usage|.
+
+The following example will add a border to the window in the default style.
+>
+  let g:git_messenger_vimpopup_win_opts = { 'border': [] }
+<
+
 ==============================================================================
 HIGHLIGHTS                                            *git-messenger-highlights*
 

--- a/doc/git-messenger.txt
+++ b/doc/git-messenger.txt
@@ -137,6 +137,7 @@ COMMANDS                                                *git-messenger-commands*
   |    D    | Toggle all unified diff hunks of the commit                  |
   |    r    | Toggle word diff hunks only in current file of the commit    |
   |    R    | Toggle all word diff hunks of the commit                     |
+  |    c    | Yank/copy the current commit hash to |v:register|              |
   |    ?    | Show mappings help                                           |
 
 *:GitMessengerClose*

--- a/syntax/gitmessengerpopup.vim
+++ b/syntax/gitmessengerpopup.vim
@@ -35,7 +35,11 @@ hi def link gitmessengerHeader      Identifier
 hi def link gitmessengerHash        Comment
 hi def link gitmessengerHistory     Constant
 hi def link gitmessengerEmail       gitmessengerPopupNormal
-hi def link gitmessengerPopupNormal NormalFloat
+if has('nvim')
+    hi def link gitmessengerPopupNormal NormalFloat
+else
+    hi def link gitmessengerPopupNormal Pmenu
+endif
 
 hi def link diffOldFile      diffFile
 hi def link diffNewFile      diffFile

--- a/test/all.vimspec
+++ b/test/all.vimspec
@@ -242,6 +242,33 @@ Describe git-messenger.vim
             Assert True(found, 'Got line: ' . string(getline(2)))
         End
 
+       It yanks current commit on c
+            GitMessenger
+            Assert IsNotNone(GetPopup())
+
+            GitMessenger
+            Assert Exists('b:__gitmessenger_popup')
+
+            call setreg(v:register, 'foo')
+            Assert Equal(getreg(v:register), 'foo')
+
+            normal c
+
+            let lines = getline(1, '$')
+            let commit = lines[2]
+            let hash = matchstr(commit, '^ Commit: \+\zs[[:xdigit:]]\{7,}$')
+            Assert Equal(getreg(v:register), hash)
+
+            " Confirm also works after moving to a different commit
+            normal o
+            normal c
+
+            let lines = getline(1, '$')
+            let commit = lines[2]
+            let hash = matchstr(commit, '^ Commit: \+\zs[[:xdigit:]]\{7,}$')
+            Assert Equal(getreg(v:register), hash)
+        End
+
         It does not cause #23 again
             " 1. Open the same buffer with multiple window
             " 2. Move cursror to the second window which opens the same


### PR DESCRIPTION
This adds optional support for using Vim popup windows, which must be
enabled by setting g:git_messenger_vimpopup_enabled to v:true, and works
similar to Neovim with g:git_messenger_always_into_popup set to v:true

It does require quite a bit of conditional code as you cannot enter a
Vim popup, unlike a Neovim float or the preview window, but it works!

Has been tested, manually, with Vim 8.1.2384 (first version of Vim to
include support for +popupwin) and with Vim 9.1.950, both work fine.

There are some limitations as you can't enter the popup, for example key
mappings are specified in a filter function, not as buffer local maps,
and there are likely to be some bugs as this is new, but generally it
works as you probably expect, the popup opens in the same position as
the Neovim floating window, the git-messenger mappings work, running the
:GitMessenger command opens and closes the popup, mouse scrolling works,
and some keys like CTRL-U, CTRL-D are mapped for scrolling up and down.

Resolves #90 
Resolves #30 